### PR TITLE
feat(text2image): Update image generation parameters

### DIFF
--- a/bot/mention/text2image.ts
+++ b/bot/mention/text2image.ts
@@ -22,9 +22,10 @@ const generateImage = async (
     },
     body: JSON.stringify({
       prompt,
+      model: "dall-e-3",
       n: 1,
       response_format: "b64_json",
-      size: "512x512",
+      size: "1024x1024",
     }),
   });
   if (!res.ok) {

--- a/bot/mention/text2image_test.ts
+++ b/bot/mention/text2image_test.ts
@@ -52,8 +52,9 @@ Deno.test("text2image", async () => {
   assertEquals(imageBody, {
     prompt,
     n: 1,
+    model: "dall-e-3",
     response_format: "b64_json",
-    size: "512x512",
+    size: "1024x1024",
   });
 
   assertEquals(uploadCalls.length, 1);


### PR DESCRIPTION
- dall-e-3 に変更
- size は 512x512 がサポートされていなかったので次点の最小サイズである 1024x1024 に変更